### PR TITLE
no static binary for MacOS, there is not static libc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -101,7 +101,9 @@ CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
 # -------------------------- x86_64 specific -----------------------------------
 else ifeq ($(HOSTARCH), x86_64)
+ifneq ($(HOSTOS),Darwin)
 TARGETS		= aprsmap-static
+endif
 XLIBS		= -lpng -ljpeg -lXext -lX11
 APRSMAP_STATIC	= aprsmap-$(HOSTARCH)
 ifeq ($(PLATFORM), x86_32)


### PR DESCRIPTION
Servus, auf MacOS gibts keine statische Version von crt0.o, so dass statisches Linken eines Binaries nicht möglich ist. Einfachster Workaround ist es, auf MacOS wie früher die dynamisch gelinkte Version zu erzeugen.