### PR TITLE
added support for ArcGIS Satellite World Imagery

### DIFF
--- a/aprsmap_common/gm.sh
+++ b/aprsmap_common/gm.sh
@@ -55,7 +55,7 @@ if [ -d $DIR ] ; then
 # try to match the requested map name with a server in the map list file
             if [ -r $MAPLIST ] ; then
                 while read tileid tileorder tileformat tileurl tileapikey tilecomment ; do
-                    if [ $tileid = $mapname ] ; then
+                    if [ "$tileid" = "$mapname" ] ; then
                         ORDER=$tileorder
                         EXTENT=$tileformat
                         SERVER=$tileurl

--- a/aprsmap_common/maplist
+++ b/aprsmap_common/maplist
@@ -1,29 +1,33 @@
-# Map Name	Format	Tile Server URL					API Key ?apikey=... or ?access_token=...	Comments
-# -------------	-------	-----------------------------------------------	-----------------------------------------------	--------------------------------------------
-tiles		png	http://tile.openstreetmap.org									OSM Carto (Standard)
-tiles2		png	http://tile.toolserver.org/tiles/osm								OSM Alternate very similar to French style
-tiles_de	png	http://tile.openstreetmap.de/tiles/osmde      							OSM German style
-tiles_fr	png	http://a.tile.openstreetmap.fr/osmfr      							OSM French style
-tiles_topo	png	http://tile.opentopomap.org									OpenTopoMap
-tiles_hikebike	png	http://www.toolserver.org/tiles/hikebike							HikeBikeMap
-tiles_humanitarian png	http://a.tile.openstreetmap.fr/hot								OSM Humanitarian style
-tiles_transport	png	http://tile.thunderforest.com/transport		<insert_api_key_here>				Thunderforest Transport (requires API key)
-tiles_landscape	png	http://tile.thunderforest.com/landscape		<insert_api_key_here>				Thunderforest Landscape (requires API key)
-tiles_outdoors	png	http://tile.thunderforest.com/outdoors		<insert_api_key_here>				Thunderforest Outdoors (requires API key)
-tiles_cycle	png	http://tile.opencyclemap.org/cycle		<insert_api_key_here>				OpenCycleMap (requires API key)
-tiles_mapboxstr jpg	https://api.mapbox.com/v4/mapbox.streets	<insert_access_token_here>			Mapbox Streets (requires access token)
-tiles_mapboxsat jpg	https://api.mapbox.com/v4/mapbox.satellite	<insert_access_token_here>			Mapbox Satellite (requires access token)
-tiles_mapboxstrsat jpg	https://api.mapbox.com/v4/mapbox.streets-satellite <insert_access_token_here>			Mapbox Streets-Satellite (requires access token)
-tiles_mapboxrbh	   jpg	https://api.mapbox.com/v4/mapbox.run-bike-hike	<insert_access_token_here>			Mapbox Run-Bike-Hike (requires access token)
-xzr_tiles	png	http://osm.oe2xzr.ampr.at/osm/tiles								OSM tiles via Hamnet oe2xzr tile server
-xzr_tiles_topo	png	http://osm.oe2xzr.ampr.at/osm/tiles_topo							Topo tiles via Hamnet oe2xzr tile server
-xzr_tiles_sat	jpg	http://osm.oe2xzr.ampr.at/osm/tiles_sat								Satellite tiles via Hamnet oe2xzr tile server
-xzr_tiles_cyclemap png	http://osm.oe2xzr.ampr.at/osm/tiles_cyclemap							CycleMap tiles via Hamnet oe2xzr tile server
+# Map Name	Order	Format	Tile Server URL					API Key						Comments
+# -------------	-------	-------	-----------------------------------------------	-----------------------------------------------	--------------------------------------------
+tiles		zxy	png	http://tile.openstreetmap.org									OSM Carto (Standard)
+tiles2		zxy	png	http://tiles.wmflabs.org/osm									OSM Mapnik
+tiles_de	zxy	png	http://tile.openstreetmap.de/tiles/osmde      							OSM German style
+tiles_fr	zxy	png	http://a.tile.openstreetmap.fr/osmfr      							OSM French style
+tiles_topo	zxy	png	http://tile.opentopomap.org									OpenTopoMap
+tiles_hikebike	zxy	png	http://tiles.wmflabs.org/hikebike								OSM Hike & Bike Map
+tiles_humanitarian zxy	png	http://a.tile.openstreetmap.fr/hot								OSM Humanitarian style
+tiles_ersisat	zyx	jpg	http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile		ArcGIS ERSI Satellite World Imagery
+tiles_transport	zxy	png	http://tile.thunderforest.com/transport		<insert_api_key_here>				Thunderforest Transport (requires API key)
+tiles_landscape	zxy	png	http://tile.thunderforest.com/landscape		<insert_api_key_here>				Thunderforest Landscape (requires API key)
+tiles_outdoors	zxy	png	http://tile.thunderforest.com/outdoors		<insert_api_key_here>				Thunderforest Outdoors (requires API key)
+tiles_cycle	zxy	png	http://tile.thunderforest.com/cycle		<insert_api_key_here>				Thunderforest OpenCycleMap (requires API key)
+tiles_mapboxstr zxy	jpg	https://api.mapbox.com/v4/mapbox.streets	<insert_access_token_here>			Mapbox Streets (requires access token)
+tiles_mapboxsat zxy	jpg	https://api.mapbox.com/v4/mapbox.satellite	<insert_access_token_here>			Mapbox Satellite (requires access token)
+tiles_mapboxstrsat zyx	jpg	https://api.mapbox.com/v4/mapbox.streets-satellite <insert_access_token_here>			Mapbox Streets-Satellite (requires access token)
+tiles_mapboxrbh zxy	jpg	https://api.mapbox.com/v4/mapbox.run-bike-hike	<insert_access_token_here>			Mapbox Run-Bike-Hike (requires access token)
+xzr_tiles	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles								OSM tiles via Hamnet oe2xzr tile server
+xzr_tiles_topo	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles_topo							Topo tiles via Hamnet oe2xzr tile server
+xzr_tiles_sat	zxy	jpg	http://osm.oe2xzr.ampr.at/osm/tiles_sat								Satellite tiles via Hamnet oe2xzr tile server
+xzr_tiles_cyclemap zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles_cyclemap							CycleMap tiles via Hamnet oe2xzr tile server
 
 # Map Name - this name matches the Map Name defined in aprsmap
+# Order - map tile structure used by tile server MUST be one of the following:
+#     zxy = {z}/{x}/{y} - the order used by most tile servers
+#     zyx = {z}/{y}/{x} - seen used by ArcGIS tile server
 # Format - this is the format & file extension of the downloaded map tile
 # Tile Server URL - in most cases, all mirrors actually resolve to the same IP address or resolve to a closest geo server
-# API Key - this optional enrtry is used to define the access key required by some tile servers and MUST have the format:
+# API Key - this optional entry is used to define the access key required by some tile servers and MUST have the format:
 #     ?apikey=<your api key>
 #     ?access_token=<your access token>
 # Comments - optional

--- a/aprsmap_common/maplist
+++ b/aprsmap_common/maplist
@@ -12,10 +12,10 @@ tiles_transport	zxy	png	http://tile.thunderforest.com/transport		<insert_api_key
 tiles_landscape	zxy	png	http://tile.thunderforest.com/landscape		<insert_api_key_here>				Thunderforest Landscape (requires API key)
 tiles_outdoors	zxy	png	http://tile.thunderforest.com/outdoors		<insert_api_key_here>				Thunderforest Outdoors (requires API key)
 tiles_cycle	zxy	png	http://tile.thunderforest.com/cycle		<insert_api_key_here>				Thunderforest OpenCycleMap (requires API key)
-tiles_mapboxstr zxy	jpg	https://api.mapbox.com/v4/mapbox.streets	<insert_access_token_here>			Mapbox Streets (requires access token)
+tiles_mapboxstr zxy	png	https://api.mapbox.com/v4/mapbox.streets	<insert_access_token_here>			Mapbox Streets (requires access token)
 tiles_mapboxsat zxy	jpg	https://api.mapbox.com/v4/mapbox.satellite	<insert_access_token_here>			Mapbox Satellite (requires access token)
-tiles_mapboxstrsat zyx	jpg	https://api.mapbox.com/v4/mapbox.streets-satellite <insert_access_token_here>			Mapbox Streets-Satellite (requires access token)
-tiles_mapboxrbh zxy	jpg	https://api.mapbox.com/v4/mapbox.run-bike-hike	<insert_access_token_here>			Mapbox Run-Bike-Hike (requires access token)
+tiles_mapboxstrsat zxy	jpg	https://api.mapbox.com/v4/mapbox.streets-satellite <insert_access_token_here>			Mapbox Streets-Satellite (requires access token)
+tiles_mapboxrbh zxy	png	https://api.mapbox.com/v4/mapbox.run-bike-hike	<insert_access_token_here>			Mapbox Run-Bike-Hike (requires access token)
 xzr_tiles	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles								OSM tiles via Hamnet oe2xzr tile server
 xzr_tiles_topo	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles_topo							Topo tiles via Hamnet oe2xzr tile server
 xzr_tiles_sat	zxy	jpg	http://osm.oe2xzr.ampr.at/osm/tiles_sat								Satellite tiles via Hamnet oe2xzr tile server

--- a/aprsmap_common/maplist
+++ b/aprsmap_common/maplist
@@ -7,7 +7,7 @@ tiles_fr	zxy	png	http://a.tile.openstreetmap.fr/osmfr      							OSM French sty
 tiles_topo	zxy	png	http://tile.opentopomap.org									OpenTopoMap
 tiles_hikebike	zxy	png	http://tiles.wmflabs.org/hikebike								OSM Hike & Bike Map
 tiles_humanitarian zxy	png	http://a.tile.openstreetmap.fr/hot								OSM Humanitarian style
-tiles_ersisat	zyx	jpg	http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile		ArcGIS ERSI Satellite World Imagery
+tiles_esrisat	zyx	jpg	http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile		ArcGIS ESRI Satellite World Imagery
 tiles_transport	zxy	png	http://tile.thunderforest.com/transport		<insert_api_key_here>				Thunderforest Transport (requires API key)
 tiles_landscape	zxy	png	http://tile.thunderforest.com/landscape		<insert_api_key_here>				Thunderforest Landscape (requires API key)
 tiles_outdoors	zxy	png	http://tile.thunderforest.com/outdoors		<insert_api_key_here>				Thunderforest Outdoors (requires API key)

--- a/aprsmap_common/maplist-hamnet
+++ b/aprsmap_common/maplist-hamnet
@@ -1,14 +1,17 @@
-# Map Name	Format	Tile Server URL					API Key ?apikey=... or ?access_token=...	Comments
-# -------------	-------	-----------------------------------------------	-----------------------------------------------	--------------------------------------------
-tiles		png	http://osm.oe2xzr.ampr.at/osm/tiles								OSM tiles via Hamnet oe2xzr tile server
-tiles_topo	png	http://osm.oe2xzr.ampr.at/osm/tiles_topo							Topo tiles via Hamnet oe2xzr tile server
-tiles_sat	jpg	http://osm.oe2xzr.ampr.at/osm/tiles_sat								Satellite tiles via Hamnet oe2xzr tile server
-tiles_cyclemap	png	http://osm.oe2xzr.ampr.at/osm/tiles_cyclemap							CycleMap tiles via Hamnet oe2xzr tile server
+# Map Name	Order	Format	Tile Server URL					API Key						Comments
+# -------------	-------	-------	-----------------------------------------------	-----------------------------------------------	--------------------------------------------
+tiles		zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles								OSM tiles via Hamnet oe2xzr tile server
+tiles_topo	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles_topo							Topo tiles via Hamnet oe2xzr tile server
+tiles_sat	zxy	jpg	http://osm.oe2xzr.ampr.at/osm/tiles_sat								Satellite tiles via Hamnet oe2xzr tile server
+tiles_cyclemap	zxy	png	http://osm.oe2xzr.ampr.at/osm/tiles_cyclemap							CycleMap tiles via Hamnet oe2xzr tile server
 
 # Map Name - this name matches the Map Name defined in aprsmap
+# Order - map tile structure used by tile server MUST be one of the following:
+#     zxy = {z}/{x}/{y} - the order used by most tile servers
+#     zyx = {z}/{y}/{x} - seen used by ArcGIS tile server
 # Format - this is the format & file extension of the downloaded map tile
 # Tile Server URL - in most cases, all mirrors actually resolve to the same IP address or resolve to a closest geo server
-# API Key - this optional enrtry is used to define the access key required by some tile servers and MUST have the format:
+# API Key - this optional entry is used to define the access key required by some tile servers and MUST have the format:
 #     ?apikey=<your api key>
 #     ?access_token=<your access token>
 # Comments - optional


### PR DESCRIPTION
The ArcGIS tile server, unlike most tile servers serves tiles using {z}/{y}/{x} coordinates.  Added a field to the map file to support specifying both {z}/{x}/{y} ordering used by most tile servers as well as the {z}/{y}/{x} map tile coordinates as seen used with the ArcGIS ERIS satellite world imagery server.  gm.sh updated to process new Order field.

Tested on Ubuntu 16.04 x86_64 and Debian 9.2 Beagleboard-xM armv7hf platforms.
73!
