### PR TITLE
Changes for current state of dxlAPRS build system and archive content

### DIFF
--- a/aprsmap_common/hints.txt
+++ b/aprsmap_common/hints.txt
@@ -127,9 +127,9 @@ is write enabled. A given File Path is used
 for watch-call and manual saved Logs too.
 Append %d for daywise logfile. "logs/rawlog%d"
 
-|309 Days Keep (dayly) Rawdata Logfiles. Purge
+|309 Days Keep (daily) Rawdata Logfiles. Purge
 starts on Program start and Midnight.
-0 Days is forever. Make dayly files
+0 Days is forever. Make daily files
 with %d at end of Logfilename like
 "logs/rawlog%d"
 
@@ -780,7 +780,7 @@ Data is stored to memory and writelog and is
 displayed again on "Exit Logview"
 
 |6705 Find Call in Logfile, exact match,
-and import it. Works only with dayly Log
+and import it. Works only with daily Log
 
 |6710 Read data from this path/filename.
 The format is Timestamp "yyyymmdd:hhmmss " in utc
@@ -788,7 +788,7 @@ followed by AprsIs Line. The data is sorted at
 import by Time, indexed and all waypoints compared
 to each other for removing dupes and stored in
 compressed form in RAM. Append %d to filename
-for dayly logs, "logs/rawlog%d"
+for daily logs, "logs/rawlog%d"
 
 |6715 
 |6716 Reload Data from Writelog

--- a/aprsmap_common/maplist
+++ b/aprsmap_common/maplist
@@ -1,6 +1,6 @@
 # Map Name	Order	Format	Tile Server URL					API Key						Comments
 # -------------	-------	-------	-----------------------------------------------	-----------------------------------------------	--------------------------------------------
-tiles		zxy	png	http://tile.openstreetmap.org									OSM Carto (Standard)
+tiles		zxy	png	https://tile.openstreetmap.org									OSM Carto (Standard)
 tiles2		zxy	png	http://tiles.wmflabs.org/osm									OSM Mapnik
 tiles_de	zxy	png	http://tile.openstreetmap.de/tiles/osmde      							OSM German style
 tiles_fr	zxy	png	http://a.tile.openstreetmap.fr/osmfr      							OSM French style

--- a/scripts/packCurrent.sh
+++ b/scripts/packCurrent.sh
@@ -7,7 +7,7 @@ fi
 
 VER=`git describe --always --dirty`
 
-BASE=src/
+BASE=out-$1/
 EXCL='arm-linux-armv7hf-gcc arm-linux-armv7hf-strip arm-linux-rpi-gcc arm-linux-rpi-strip'
 FLIST=`ls $BASE`
 PACKLIST=""

--- a/scripts/updateDXLaprs
+++ b/scripts/updateDXLaprs
@@ -55,7 +55,8 @@ if [ -r $FILE.tgz ]; then
 	rm $FILE.tar
 	echo "Installation directory:" $DST
 	echo "Installing aprsmap-components..."
-	mv -f aprsmap_common/poi.txt $DSTMAP/osm/
+	cp -r aprsmap_common/osm $DSTMAP
+	rm -r aprsmap_common/osm
 	mv -f aprsmap_common/* $DSTMAP/
 	rm -r aprsmap_common
 	mv -f aprsmap* $DSTMAP/


### PR DESCRIPTION
Hello!  Just some updates to a few scripts to work with the current build process.
packCurrent now looks in the out- directory for executables. Moved this script to scripts directory.
updateDXLaprs now works properly with the updated osm/poi directory structure.
maplist now uses https with tile.openstreetmap.org as now recommended at https://wiki.openstreetmap.org/wiki/Tile_servers