### PR TITLE
Fix problems downloading tiles from openstreetmap.org, allow native ARM fftw3 builds, fix various build problems with gcc14 based toolchains

### DIFF
--- a/aprsmap_common/gm.sh
+++ b/aprsmap_common/gm.sh
@@ -20,17 +20,26 @@
 
 #------------------------------------------------------------------------------
 
+# name of application + name of this script, version and source of this script
+NAME="aprsmap+gm.sh"
+VERSION="1.0"
+SOURCE="http://github.com/oe5hpm/dxlAPRS"
+
 # file created by aprsmap of a list of map tiles to fetch
 ORIGFN="gettiles"
 
 # default filename for list of available maps
 MAPFN="maplist"
 
+# User-Agent is now required by OSM policy
+USER_AGENT="$NAME/$VERSION $SOURCE"
+
 # sample commands to retrieve map tiles showing wget and curl usage
-# blank user-agent, quiet mode, 5 sec timeout, 1 retry, output file follows
-GETCMDBASE="wget -U \"\" -q -T 5 -t 1 -O"
-#GETCMDBASE="wget2 -U \"\" -q -T 5 -t 1 -O"
-#GETCMDBASE="curl -A \"\" -s -S -m 5 -o"
+# user-agent, quiet mode, 5 sec timeout, 1 retry, output file follows
+
+GETCMDBASE="wget -U \"$USER_AGENT\" -q -T 5 -t 1 -O"
+#GETCMDBASE="wget2 -U \"$USER_AGENT\" -q -T 5 -t 1 -O"
+#GETCMDBASE="curl -A \"$USER_AGENT\" -s -S -m 5 -o"
 
 #------------------------------------------------------------------------------
 

--- a/scripts/updateDXLaprs
+++ b/scripts/updateDXLaprs
@@ -4,13 +4,28 @@
 
 if [ -z $1 ]; then
 	echo "updateDXLaprs: missing architecture or local image file"
-	echo "Usage: updateDXLaprs ARCH | file"
+	echo "Usage: updateDXLaprs ARCH | file [executables]"
 	echo "    Where ARCH may be: armv6, armv6tce, armv7hf, x86_32, x86_64, ..."
 	echo ""
 	echo "    If a local file is specified instead of one of the architectures above,"
 	echo "    then this file will be used for performing the installation. The local"
 	echo "    file must be a file that was created by the packCurrent.sh script."
+	echo ""
+	echo "    If \"executables\" option is specified, then only executable files and"
+	echo "    scripts will be updated. All other files in the destination directories"
+	echo "    remain untouched."
 	exit 1
+fi
+
+if [ $2 ]; then
+	if [ "executables" != $2 ]; then
+		echo "2nd argument must be either blank or \"executables\""
+		exit
+	else
+		EXECS=$2
+	fi
+else
+	EXECS="install"
 fi
 
 # url and the template basename (no file extension) of installation archive
@@ -33,8 +48,10 @@ GETCMDBASE="wget"
 
 # set up the default destination directory structure
 [ -d $DSTMAP ] || mkdir -p $DSTMAP
-[ -d $DSTMAP/$MAPDIR ] || mkdir -p $DSTMAP/$MAPDIR
-[ -d $DSTMAP/$LOGDIR ] || mkdir -p $DSTMAP/$LOGDIR
+if [ "executables" != $EXECS ]; then
+	[ -d $DSTMAP/$MAPDIR ] || mkdir -p $DSTMAP/$MAPDIR
+	[ -d $DSTMAP/$LOGDIR ] || mkdir -p $DSTMAP/$LOGDIR
+fi
 [ -d $DSTAPRS ] || mkdir -p $DSTAPRS
 
 # retrieve the image
@@ -65,6 +82,21 @@ if [ -r $FILE.tgz ]; then
 	tar -xf $FILE.tar
 	rm $FILE.tar
 	echo "Installation directory:" $DST
+#if only installing executable binaries and executable scripts
+if [ "executables" = $EXECS ]; then
+	echo "Updating aprs executables..."
+	for f in $(ls); do
+		test -f $f && test -x $f && mv -f $f $DSTAPRS/
+	done
+	cp -r scripts $DSTAPRS/
+	rm -r scripts
+	echo "Updating aprsmap executables..."
+	mv -f $DSTAPRS/aprsmap* $DSTMAP/
+	for f in $(ls aprsmap_common); do
+		test -f aprsmap_common/$f && test -x aprsmap_common/$f && mv -f aprsmap_common/$f $DSTMAP/
+	done
+else
+# full installation
 	echo "Installing aprsmap directory components..."
 	cp -r aprsmap_common/$MAPDIR $DSTMAP
 	rm -r aprsmap_common/$MAPDIR
@@ -77,6 +109,7 @@ if [ -r $FILE.tgz ]; then
 	cp -r scripts $DSTAPRS/
 	rm -r scripts
 	mv -f * $DSTAPRS/
+fi
 
 # fixup file permissions and owners
 	cd $DSTAPRS

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,18 +94,11 @@ endif
 ifeq ($(PLATFORM), armv6tce)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6tce/)
 EXTLIB  	= lib_armv6/
-# if we are building on the host for the host and not cross-compiling
-ifeq ($(HOSTARCH), $(PLATFORM))
-GFXLIBS		= -lpng -ljpeg
-XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
-TARGETS		+=	$(OUT)aprsmap
-else
 GFXLIBS		= $(EXTLIB)libpng15/libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 			  -L$(EXTLIB) -lXext -lX11
-endif
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng15/ -I$(EXTLIB) -I.
 LFLAGS		+=
@@ -113,18 +106,11 @@ TARGETS		+=	$(OUT)aprsmap
 else ifeq ($(PLATFORM), armv6)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6/)
 EXTLIB  	= lib_armv6/
-# if we are building on the host for the host and not cross-compiling
-ifeq ($(HOSTARCH), $(PLATFORM))
-GFXLIBS		= -lpng -ljpeg
-XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
-TARGETS		+=	$(OUT)aprsmap
-else
 GFXLIBS		= $(EXTLIB)libpng16/libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 			 -L$(EXTLIB) -lXext -lX11
-endif
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng16/ -I$(EXTLIB) -I.
 LFLAGS		+=
@@ -133,30 +119,25 @@ TARGETS		+=	$(OUT)aprsmap
 else ifeq ($(PLATFORM), armv7hf)
 OUT		:= $(if $(OUT),$(OUT),../out-armv7hf/)
 EXTLIB		= lib_armv7hf/
-# if we are building on the host for the host and not cross-compiling
-ifeq ($(HOSTARCH), $(PLATFORM))
-GFXLIBS		= -lpng -ljpeg
-XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
-TARGETS		+=	$(OUT)aprsmap
-else
 GFXLIBS		= $(EXTLIB)libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 			 -L$(EXTLIB) -lXext -lX11
-endif
 CFLAGS		+= -march=armv7-a -mfpu=neon -mfloat-abi=hard
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
 TARGETS		+=	$(OUT)aprsmap
-# ---------------------- aarch64 (>= rpi 4+) specific -------------------------
+# ---------------------- aarch64 (>= rpi 4) specific --------------------------
 else ifeq ($(PLATFORM), aarch64)
 OUT		:= $(if $(OUT),$(OUT),../out-aarch64/)
 EXTLIB		= lib_aarch64/
 # if we are building on the host for the host and not cross-compiling
 ifeq ($(HOSTARCH), $(PLATFORM))
-GFXLIBS		= -lpng -ljpeg
-XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
+GFXLIBS		=  $(EXTLIB)libpng.a \
+			  $(EXTLIB)libz.a \
+			  $(EXTLIB)libjpeg.a
+XLIBS		= -L$(EXTLIB) -lXext -lX11
 TARGETS		+=	$(OUT)aprsmap
 else
 GFXLIBS		=  $(EXTLIB)libpng.a \
@@ -626,6 +607,7 @@ $(OUT)ra02waterfall: $(OBJ_RA02WATERFALL) $(OBJ_COMMON)
 	make $(OUT)$@
 
 diag:
+	@echo "CROSS_COMPILE   : $(CROSS_COMPILE)"
 	@echo "GCCVERSION      : $(GCCVERSION)"
 	@echo "GCCVERSION_GE14 : $(GCCVERSION_GE14)"
 	@echo "HOSTOS          : $(HOSTOS)"

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,13 +50,13 @@ export HOSTOS
 
 ifeq ($(HOSTOS),Darwin)
 # Using gcc as symlink to Mac's clan
-GCCVERSION_GE4 := true
+GCCVERSION_GE14 := true
 STRIPFLAGS =
 else
 GCCVERSION := $(shell $(CROSS_COMPILE)gcc --version | \
 	grep gcc | sed 's/.*gcc (.*) //g' | cut -d '.' -f 1)
 
-GCCVERSION_GE4 := $(shell [ $(GCCVERSION) -ge 4 ] && echo true)
+GCCVERSION_GE14 := $(shell [ $(GCCVERSION) -ge 14 ] && echo true)
 STRIPFLAGS = -s
 endif
 
@@ -66,7 +66,7 @@ endif
 CC		= $(CROSS_COMPILE)gcc
 STRIP		= $(CROSS_COMPILE)strip
 INCL		= .
-ifeq ($(GCCVERSION_GE4),true)
+ifeq ($(GCCVERSION_GE14),true)
 CDEFS		= -Wall \
 		  -Wno-unused-variable -Wno-parentheses -Wno-pointer-sign \
 		  -Wno-format -Wno-return-type -Wno-char-subscripts \
@@ -75,6 +75,13 @@ CDEFS		= -Wall \
 else
 CDEFS		= -w
 endif
+
+# FIXME: using no-error on incompatible-pointer-types
+# to allow source to compile with gcc 14+
+ifeq ($(GCCVERSION_GE14),true)
+CDEFS		+= -Wno-error=incompatible-pointer-types
+endif
+# ENDFIXME
 
 ifeq ($(HOSTOS),Darwin)
 CFLAGS		= -I$(INCL) -c -O2 -fdata-sections -ffunction-sections -I/usr/X11/include -DMACOS
@@ -87,11 +94,18 @@ endif
 ifeq ($(PLATFORM), armv6tce)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6tce/)
 EXTLIB  	= lib_armv6/
+# if we are building on the host for the host and not cross-compiling
+ifeq ($(HOSTARCH), $(PLATFORM))
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
+TARGETS		+=	$(OUT)aprsmap
+else
 GFXLIBS		= $(EXTLIB)libpng15/libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 			  -L$(EXTLIB) -lXext -lX11
+endif
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng15/ -I$(EXTLIB) -I.
 LFLAGS		+=
@@ -99,11 +113,18 @@ TARGETS		+=	$(OUT)aprsmap
 else ifeq ($(PLATFORM), armv6)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6/)
 EXTLIB  	= lib_armv6/
+# if we are building on the host for the host and not cross-compiling
+ifeq ($(HOSTARCH), $(PLATFORM))
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
+TARGETS		+=	$(OUT)aprsmap
+else
 GFXLIBS		= $(EXTLIB)libpng16/libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 			 -L$(EXTLIB) -lXext -lX11
+endif
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng16/ -I$(EXTLIB) -I.
 LFLAGS		+=
@@ -112,24 +133,38 @@ TARGETS		+=	$(OUT)aprsmap
 else ifeq ($(PLATFORM), armv7hf)
 OUT		:= $(if $(OUT),$(OUT),../out-armv7hf/)
 EXTLIB		= lib_armv7hf/
+# if we are building on the host for the host and not cross-compiling
+ifeq ($(HOSTARCH), $(PLATFORM))
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
+TARGETS		+=	$(OUT)aprsmap
+else
 GFXLIBS		= $(EXTLIB)libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 			 -L$(EXTLIB) -lXext -lX11
+endif
 CFLAGS		+= -march=armv7-a -mfpu=neon -mfloat-abi=hard
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
 TARGETS		+=	$(OUT)aprsmap
-# ---------------------- aarcg64 (rpi 4) specific -----------------------------
+# ---------------------- aarch64 (>= rpi 4+) specific -------------------------
 else ifeq ($(PLATFORM), aarch64)
 OUT		:= $(if $(OUT),$(OUT),../out-aarch64/)
 EXTLIB		= lib_aarch64/
+# if we are building on the host for the host and not cross-compiling
+ifeq ($(HOSTARCH), $(PLATFORM))
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= $(EXTLIB)libfftw3.a -lXext -lX11
+TARGETS		+=	$(OUT)aprsmap
+else
 GFXLIBS		=  $(EXTLIB)libpng.a \
 			  $(EXTLIB)libz.a \
 			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 			 -L$(EXTLIB) -lXext -lX11
+endif
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
 # -------------------------- x86_64 specific -----------------------------------
@@ -201,11 +236,11 @@ OBJ_SONDEUDP	= \
 
 OBJ_UDPBOX	= \
 	$(OUT)udpbox.o
-	
+
 OBJ_UDPGATE4	= \
 	$(OUT)udpgate4.o \
 	$(OUT)libsrtm.o
-	
+
 OBJ_UDPFLEX	= \
 	$(OUT)udpflex.o
 
@@ -403,6 +438,16 @@ clean:
 prepare:
 	@test -d $(OUT) || mkdir -p $(OUT)
 
+# FIXME: compile with c17 until the name of function bool() is changed
+# in the original l2.m2 modula-2 source code. when changed, delete this
+# to use normal make rule for .o above.
+ifeq ($(GCCVERSION_GE14),true)
+$(OUT)l2.o: l2.c
+	@echo [FIXME: compiling using std=c17] $@
+	@$(CC) $(CDEFS) $(CFLAGS) -std=c17 -o $@ $<
+endif
+# ENDFIXME
+
 $(OUT)afskmodem: $(OBJ_AFSKMODEM) $(OBJ_COMMON)
 	@echo [ linking ] $@
 	@$(CC) $(LFLAGS) -o $@ $(OBJ_COMMON) $(OBJ_AFSKMODEM) -lm
@@ -528,7 +573,7 @@ $(OUT)waterfall: $(OBJ_WATERFALL) $(OBJ_COMMON)
 
 $(OUT)waterfall3: $(OBJ_WATERFALL3) $(OBJ_COMMON)
 	@echo [ linking ] $@
-	$(CC) $(LFLAGS) -o $@ $(OBJ_WATERFALL3) $(OBJ_COMMON) $(GFXLIBS) $(EXTLIB)libfftw3.a -lm
+	@$(CC) $(LFLAGS) -o $@ $(OBJ_WATERFALL3) $(OBJ_COMMON) $(GFXLIBS) $(EXTLIB)libfftw3.a -lm
 	@$(STRIP) $@ $(STRIPFLAGS)
 
 $(OUT)downsample: $(OBJ_DOWNSAMPLE) $(OBJ_COMMON)
@@ -581,7 +626,21 @@ $(OUT)ra02waterfall: $(OBJ_RA02WATERFALL) $(OBJ_COMMON)
 	make $(OUT)$@
 
 diag:
-	@echo "Hostarch    : $(HOSTARCH)"
-	@echo "BuildOutput : $(OUT)"
-	@echo "Platform    : $(PLATFORM)"
+	@echo "GCCVERSION      : $(GCCVERSION)"
+	@echo "GCCVERSION_GE14 : $(GCCVERSION_GE14)"
+	@echo "HOSTOS          : $(HOSTOS)"
+	@echo "HOSTARCH        : $(HOSTARCH)"
+	@echo "PLATFORM        : $(PLATFORM)"
+	@echo "OUT             : $(OUT)"
+	@echo "CC              : $(CC)"
+	@echo "INCL            : $(INCL)"
+	@echo "CFLAGS          : $(CFLAGS)"
+	@echo "CDEFS           : $(CDEFS)"
+	@echo "LFLAGS          : $(LFLAGS)"
+	@echo "EXTLIB          : $(EXTLIB)"
+	@echo "GFXLIBS         : $(GFXLIBS)"
+	@echo "XLIBS           : $(XLIBS)"
+	@echo "STRIP           : $(STRIP)"
+	@echo "STRIPFLAGS      : $(STRIPFLAGS)"
+	@echo "TARGETS         : $(TARGETS)"
 # end of makefile

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,7 +115,7 @@ CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng16/ -I$(EXTLIB) -I.
 LFLAGS		+=
 TARGETS		+=	$(OUT)aprsmap
-# ---------------------- armv7hf (bur am335x pp) specific ---------------------
+# ---------------------- armv7hf ( ARMv7 ) specific ---------------------------
 else ifeq ($(PLATFORM), armv7hf)
 OUT		:= $(if $(OUT),$(OUT),../out-armv7hf/)
 EXTLIB		= lib_armv7hf/
@@ -128,27 +128,24 @@ CFLAGS		+= -march=armv7-a -mfpu=neon -mfloat-abi=hard
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
 TARGETS		+=	$(OUT)aprsmap
-# ---------------------- aarch64 (>= rpi 4) specific --------------------------
+# ---------------------- aarch64 ( >= ARMv8 ) specific ------------------------
 else ifeq ($(PLATFORM), aarch64)
 OUT		:= $(if $(OUT),$(OUT),../out-aarch64/)
 EXTLIB		= lib_aarch64/
+GFXLIBS		=  $(EXTLIB)libpng.a \
+			  $(EXTLIB)libz.a \
+			  $(EXTLIB)libjpeg.a
 # if we are building on the host for the host and not cross-compiling
 ifeq ($(HOSTARCH), $(PLATFORM))
-GFXLIBS		=  $(EXTLIB)libpng.a \
-			  $(EXTLIB)libz.a \
-			  $(EXTLIB)libjpeg.a
 XLIBS		= -L$(EXTLIB) -lXext -lX11
-TARGETS		+=	$(OUT)aprsmap
 else
-GFXLIBS		=  $(EXTLIB)libpng.a \
-			  $(EXTLIB)libz.a \
-			  $(EXTLIB)libjpeg.a
 XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 			 -L$(EXTLIB) -lXext -lX11
 endif
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
-# -------------------------- x86_64 specific -----------------------------------
+TARGETS		+=	$(OUT)aprsmap
+# -------------------------- x86_64 specific ----------------------------------
 else ifeq ($(HOSTARCH), x86_64)
 GFXLIBS		= -lpng -ljpeg
 XLIBS		= -lXext -lX11

--- a/src/lib_aarch64/build_aarch64_fftw3
+++ b/src/lib_aarch64/build_aarch64_fftw3
@@ -1,7 +1,24 @@
 #!/bin/bash
 SRC_TARBALL=../../fftw-3.3.10.tar.gz
 BUILDDIR=`mktemp -d`
+
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "aarch64" = $HOSTARCH ] ; then
+export CC=gcc
+else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+fi
+
 export CFLAGS=""
 
 cp $SRC_TARBALL $BUILDDIR
@@ -15,4 +32,3 @@ popd
 cp $BUILDDIR/lib/libfftw3*.a .
 cp $BUILDDIR/include/fftw3.h .
 rm -r -f $BUILDDIR
-

--- a/src/lib_aarch64/build_aarch64_libjpeg
+++ b/src/lib_aarch64/build_aarch64_libjpeg
@@ -1,8 +1,25 @@
 #!/bin/bash
 SRC_TARBALL=../../jpegsrc.v9.tar.gz
 BUILDDIR=`mktemp -d`
+
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "aarch64" = $HOSTARCH ] ; then
+export CC=gcc
+export CFLAGS=""
+else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
 export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8"
+fi
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR

--- a/src/lib_aarch64/build_aarch64_libpng
+++ b/src/lib_aarch64/build_aarch64_libpng
@@ -3,7 +3,22 @@ SRC_TARBALL=../../libpng-1.6.3.tgz
 BUILDDIR=`mktemp -d`
 DESTPATH=`pwd`
 
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "aarch64" = $HOSTARCH ] ; then
+export CC=gcc
+else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+fi
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR

--- a/src/lib_aarch64/build_aarch64_zlib
+++ b/src/lib_aarch64/build_aarch64_zlib
@@ -1,7 +1,24 @@
 #!/bin/bash
 SRC_TARBALL=../../zlib-1.2.8.tar.gz
 BUILDDIR=`mktemp -d`
+
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "aarch64" = $HOSTARCH ] ; then
+export CC=gcc
+else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc
+fi
+
 export CFLAGS=""
 
 cp $SRC_TARBALL $BUILDDIR

--- a/src/lib_armv6/build_armv6_fftw3
+++ b/src/lib_armv6/build_armv6_fftw3
@@ -1,7 +1,24 @@
 #!/bin/bash
 SRC_TARBALL=../../fftw-3.3.10.tar.gz
 BUILDDIR=`mktemp -d`
+
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "armv6" = $HOSTARCH ] ; then
+export CC=gcc
+else
 export CC=/opt/rpi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/bin/arm-bcm2708hardfp-linux-gnueabi-gcc
+fi
+
 export CFLAGS="-march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s"
 
 cp $SRC_TARBALL $BUILDDIR
@@ -15,4 +32,3 @@ popd
 cp $BUILDDIR/lib/libfftw*.a .
 cp $BUILDDIR/include/fftw3.h .
 rm -r -f $BUILDDIR
-

--- a/src/lib_armv7hf/build_armv7hf_fftw3
+++ b/src/lib_armv7hf/build_armv7hf_fftw3
@@ -1,7 +1,24 @@
 #!/bin/bash
 SRC_TARBALL=../../fftw-3.3.10.tar.gz
 BUILDDIR=`mktemp -d`
+
+HOSTARCH=$(uname -m | \
+	sed -e s/i.86/x86/ \
+	    -e s/sun4u/sparc64/ \
+	    -e s/arm.*/arm/ \
+	    -e s/sa110/arm/ \
+	    -e s/ppc64/powerpc/ \
+	    -e s/ppc/powerpc/ \
+	    -e s/macppc/powerpc/\
+	    -e s/sh.*/sh/)
+
+# if we are building on the host for the host and not cross-compiling
+if [ "armv7hf" = $HOSTARCH ] ; then
+export CC=gcc
+else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
+fi
+
 export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8"
 
 cp $SRC_TARBALL $BUILDDIR
@@ -15,4 +32,3 @@ popd
 cp $BUILDDIR/lib/libfftw3*.a .
 cp $BUILDDIR/include/fftw3.h .
 rm -r -f $BUILDDIR
-


### PR DESCRIPTION
1) Fixed map retrieval from openstreetmap.org
OSM now enforcing policy requiring a valid User-Agent to download maptiles from their server tile.openstreetmap.org. Blank User-Agent prevented map tiles from being downloaded. Created a User-Agent to fix problems downloading maps from OSM.
-----
2) Allow fftw3 library for ARM-based envrionments to be built using native build tools
lib_\<arm arch\> fftw3 build files now try to detect if building natively. This will allow ARM-based Linux users (e.g. RPi)
to use the native compiler installed to build the fftw3 library for subsequent use in the build of the application.
-----
3) Work around various build problems starting with gcc 14-based toolchains
Corrected some native build problems for ARM-based hosts.
Changes to get the build working again on gcc14 based compilers.

All changes were made trying to preserve the original cross-build behaviors since I don't know how the images
at http://dxlaprs.hamspirit.at/ are created. I suspect the ARM targets are cross-built on x86.

The build process for native host builds looks like this. Starting from the directory dxlAPRS/src
Raspberry Pi 5 Linux example:
cd lib_aarch64
./build_aarch64_fftw3
./build_aarch64_libpng
./build_aarch64_libjpeg
./build_aarch64_zlib
cd ..
make PLATFORM=aarch64

x86_64 PC Linux example:
cd lib_x86_64
./build_x86_64_fftw3
cd ..
make PLATFORM=x86_64
