### PR TITLE
Get the Makefile "(default)" build path working again given fftw3 components are always expected in src/lib_<hostarch>

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -34,22 +34,28 @@
 # - lorarx IQ file with lora to axudp
 # - ttytee read serial port and send to unbreakable pipe(s)
 # ---------------------- common section ---------------------------------------
-HOSTARCH := $(shell uname -m | \
-	sed -e s/i.86/x86/ \
-	    -e s/sun4u/sparc64/ \
-	    -e s/arm.*/arm/ \
-	    -e s/sa110/arm/ \
-	    -e s/ppc64/powerpc/ \
-	    -e s/ppc/powerpc/ \
-	    -e s/macppc/powerpc/\
-	    -e s/sh.*/sh/)
+# try to normalize the host architecture for the default build case so that the
+# correct lib_$(HOSTARCH) directory will be used to find e.g. fftw3 components
+MACHINE = $(shell uname -m)
+ifeq ($(MACHINE), arm)
+HOSTARCH := armv6
+else
+HOSTARCH := $(shell echo $(MACHINE) | \
+	sed -e s/i.86/x86_32/ \
+	    -e s/x86-64/x86_64/ \
+	    -e s/amd64/x86_64/ \
+	    -e s/armv6.*/armv6/ \
+	    -e s/armv7.*/armv7hf/ \
+	    -e s/armv8.*/aarch64/ \
+	    -e s/armv9.*/aarch64/)
+endif
 export HOSTARCH
 
 HOSTOS := $(shell uname -s)
 export HOSTOS
 
 ifeq ($(HOSTOS),Darwin)
-# Using gcc as symlink to Mac's clan
+# Using gcc as symlink to Mac's clang
 GCCVERSION_GE14 := true
 STRIPFLAGS =
 else
@@ -66,7 +72,12 @@ endif
 CC		= $(CROSS_COMPILE)gcc
 STRIP		= $(CROSS_COMPILE)strip
 INCL		= .
-ifeq ($(GCCVERSION_GE14),true)
+# turn warnings on only when debugging. because the c code here is mainly a
+# machine-translation of the original modula-2 sources into c, we are at the
+# mercy of the translator from the upstream source. "make DEBUG=true" will
+# turn compiler warnings back on if necessary. otherwise, simply suppress
+# warnings for the average user.
+ifeq ($(DEBUG),true)
 CDEFS		= -Wall \
 		  -Wno-unused-variable -Wno-parentheses -Wno-pointer-sign \
 		  -Wno-format -Wno-return-type -Wno-char-subscripts \
@@ -77,7 +88,7 @@ CDEFS		= -w
 endif
 
 # FIXME: using no-error on incompatible-pointer-types
-# to allow source to compile with gcc 14+
+# to allow source to compile with gcc 14+ and hope it all works.
 ifeq ($(GCCVERSION_GE14),true)
 CDEFS		+= -Wno-error=incompatible-pointer-types
 endif
@@ -90,6 +101,9 @@ else
 CFLAGS		= -I$(INCL) -c -O2 -fdata-sections -ffunction-sections
 LFLAGS		= -Wl,--gc-sections
 endif
+
+TARGETS		= $(OUT)aprsmap
+
 # ---------------------- armv6 (raspberry pi 1) specific -----------------------
 ifeq ($(PLATFORM), armv6tce)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6tce/)
@@ -102,7 +116,6 @@ XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng15/ -I$(EXTLIB) -I.
 LFLAGS		+=
-TARGETS		+=	$(OUT)aprsmap
 else ifeq ($(PLATFORM), armv6)
 OUT		:= $(if $(OUT),$(OUT),../out-armv6/)
 EXTLIB  	= lib_armv6/
@@ -114,7 +127,6 @@ XLIBS		= $(EXTLIB)libxcb.so.1 $(EXTLIB)libXdmcp.so.6 $(EXTLIB)libXau.so.6 \
 CFLAGS		+= -march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s
 CFLAGS		+= -Ilib_armv6/libpng16/ -I$(EXTLIB) -I.
 LFLAGS		+=
-TARGETS		+=	$(OUT)aprsmap
 # ---------------------- armv7hf ( ARMv7 ) specific ---------------------------
 else ifeq ($(PLATFORM), armv7hf)
 OUT		:= $(if $(OUT),$(OUT),../out-armv7hf/)
@@ -127,7 +139,6 @@ XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 CFLAGS		+= -march=armv7-a -mfpu=neon -mfloat-abi=hard
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
-TARGETS		+=	$(OUT)aprsmap
 # ---------------------- aarch64 ( >= ARMv8 ) specific ------------------------
 else ifeq ($(PLATFORM), aarch64)
 OUT		:= $(if $(OUT),$(OUT),../out-aarch64/)
@@ -144,17 +155,17 @@ XLIBS		= $(EXTLIB)libxcb.so $(EXTLIB)libXdmcp.so $(EXTLIB)libXau.so \
 endif
 CFLAGS		+= -I$(EXTLIB)
 LFLAGS		+=
-TARGETS		+=	$(OUT)aprsmap
 # -------------------------- x86_64 specific ----------------------------------
 else ifeq ($(HOSTARCH), x86_64)
-GFXLIBS		= -lpng -ljpeg
-XLIBS		= -lXext -lX11
-CFLAGS		+= -I$(EXTLIB)
 EXTLIB		= lib_x86_64/
-TARGETS		+=	$(OUT)aprsmap
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= -L$(EXTLIB) -lXext -lX11
+CFLAGS		+= -I$(EXTLIB)
+# if cross-compiling for x86_32 on x86_64 host
 ifeq ($(PLATFORM), x86_32)
-	EXTLIB	= lib_x86_32/
 	OUT	:= $(if $(OUT),$(OUT),../out-x86_32/)
+	EXTLIB	= lib_x86_32/
+	XLIBS	= -L$(EXTLIB) -lXext -lX11
 	CFLAGS	+= -m32
 	LFLAGS	+= -m32
 	TARGETS	+= $(OUT)aprsmap-x86_32
@@ -162,17 +173,25 @@ else ifneq ($(HOSTOS),Darwin)
 TARGETS		+= $(OUT)aprsmap-x86_64
 endif
 OUT		:= $(if $(OUT),$(OUT),../out-x86_64/)
-# -------------------------- x86_32 (default) specific ------------------------
+# -------------------------- x86_32 specific ----------------------------------
 else ifeq ($(HOSTARCH), x86)
 OUT		:= $(if $(OUT),$(OUT),../out-x86_32/)
+EXTLIB		= lib_x86_32/
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= -L$(EXTLIB) -lXext -lX11
+CFLAGS		+= -I$(EXTLIB)
 TARGETS		+= $(OUT)aprsmap-x86_32
-GFXLIBS		=-lpng -ljpeg
-XLIBS		= -lXext -lX11
+# ---- (default) PLATFORM none of the above and not on a x86-based host -------
+# you must first manually remove all .h, .a and .so files down in
+# lib_$(HOSTARCH) then run only the fftw3 builder prior to make. the host's
+# own installed png, jpeg, x11 libs as well as shared objects will then be
+# used for build and execution.
 else
-OUT		:= $(if $(OUT),$(OUT),../out/)
-GFXLIBS		+= -lpng -ljpeg
-XLIBS		+=-lXext -lX11
-TARGETS		+=	$(OUT)aprsmap
+OUT		:= $(if $(OUT),$(OUT),../out-$(HOSTARCH)/)
+EXTLIB		= lib_$(HOSTARCH)/
+GFXLIBS		= -lpng -ljpeg
+XLIBS		= -L$(EXTLIB) -lXext -lX11
+CFLAGS		+= -I$(EXTLIB)
 endif
 # ------------------ objects enumeration ------------------
 OBJ_COMMON = \
@@ -417,7 +436,7 @@ prepare:
 	@test -d $(OUT) || mkdir -p $(OUT)
 
 # FIXME: compile with c17 until the name of function bool() is changed
-# in the original l2.m2 modula-2 source code. when changed, delete this
+# in the original l2.mod modula-2 source code. when changed, delete this
 # to use normal make rule for .o above.
 ifeq ($(GCCVERSION_GE14),true)
 $(OUT)l2.o: l2.c
@@ -604,10 +623,12 @@ $(OUT)ra02waterfall: $(OBJ_RA02WATERFALL) $(OBJ_COMMON)
 	make $(OUT)$@
 
 diag:
+	@echo "DEBUG           : $(DEBUG)"
 	@echo "CROSS_COMPILE   : $(CROSS_COMPILE)"
 	@echo "GCCVERSION      : $(GCCVERSION)"
 	@echo "GCCVERSION_GE14 : $(GCCVERSION_GE14)"
 	@echo "HOSTOS          : $(HOSTOS)"
+	@echo "MACHINE         : $(MACHINE)"
 	@echo "HOSTARCH        : $(HOSTARCH)"
 	@echo "PLATFORM        : $(PLATFORM)"
 	@echo "OUT             : $(OUT)"

--- a/src/README
+++ b/src/README
@@ -1,4 +1,33 @@
-compiling hints for C-Sources by OE5HPM@OE5XBL.#OE5.AUT.EU
+compiling hints for C-Sources by OE5HPM@OE5XBL.#OE5.AUT.EU and
+DL5MGZ/KN6EI (https://github.com/t52ta6ek)
+
+for all builds intended to run on your host platform it is highly recommended
+you remove any .h, .a, and shared objects that may pre-exist when you cloned
+the repository prior to running the "make".
+
+if you plan to use the png, jpeg, x11 libraries you installed onto your host
+system (e.g. as described below) the step above is especially important. the
+build process will then use your own system's libraries.
+
+In most cases, you may then only need to regenerate the fftw3 .h and .a files
+by simply executing the fftw3 build script present in the src/lib_<hostarch>
+directory.
+
+these src/lib_<hostarch>/build files in most cases will now attempt to
+determine if you are trying to build on your host for your host vs cross-
+compiling. if not cross-compiling, your host's compiler will be used for
+the "configure" process. else the cross-toolchain will be used.
+
+however, for a PLATFORM build, those .h, .a and any shared objects in
+addition to the fftw3 components will need to be present. build these as
+necessary.
+
+to asist debugging the build, you may do either
+make PLATFORM=<hostarch> diag
+or
+make diag
+
+where <hostarch> may be currently: armv6tce, armv6, armv7hf, x86_32, x86_64
 
 build for X86 with i386 (32-bit) host system
 or

--- a/src/lib_aarch64/build_aarch64_fftw3
+++ b/src/lib_aarch64/build_aarch64_fftw3
@@ -1,16 +1,13 @@
 #!/bin/bash
-SRC_TARBALL=../../fftw-3.3.10.tar.gz
+LIB=fftw-3.3.10.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 HOSTARCH=$(uname -m | \
-	sed -e s/i.86/x86/ \
-	    -e s/sun4u/sparc64/ \
-	    -e s/arm.*/arm/ \
-	    -e s/sa110/arm/ \
-	    -e s/ppc64/powerpc/ \
-	    -e s/ppc/powerpc/ \
-	    -e s/macppc/powerpc/\
-	    -e s/sh.*/sh/)
+	sed -e s/arm64/aarch64/ \
+	    -e s/armv8.*/aarch64/ \
+	    -e s/armv9.*/aarch64/)
 
 # if we are building on the host for the host and not cross-compiling
 if [ "aarch64" = $HOSTARCH ] ; then
@@ -23,12 +20,11 @@ export CFLAGS=""
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --host=arm-none-linux-gnueabi
 make -j16
 make install
 popd
-cp $BUILDDIR/lib/libfftw3*.a .
-cp $BUILDDIR/include/fftw3.h .
+cp $BUILDDIR/lib/*.a .
+cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR

--- a/src/lib_aarch64/build_aarch64_libjpeg
+++ b/src/lib_aarch64/build_aarch64_libjpeg
@@ -1,16 +1,13 @@
 #!/bin/bash
-SRC_TARBALL=../../jpegsrc.v9.tar.gz
+LIB=jpegsrc.v9.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 HOSTARCH=$(uname -m | \
-	sed -e s/i.86/x86/ \
-	    -e s/sun4u/sparc64/ \
-	    -e s/arm.*/arm/ \
-	    -e s/sa110/arm/ \
-	    -e s/ppc64/powerpc/ \
-	    -e s/ppc/powerpc/ \
-	    -e s/macppc/powerpc/\
-	    -e s/sh.*/sh/)
+	sed -e s/arm64/aarch64/ \
+	    -e s/armv8.*/aarch64/ \
+	    -e s/armv9.*/aarch64/)
 
 # if we are building on the host for the host and not cross-compiling
 if [ "aarch64" = $HOSTARCH ] ; then
@@ -18,13 +15,12 @@ export CC=gcc
 export CFLAGS=""
 else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
-export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8"
+export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard"
 fi
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf jpegsrc.v9.tar.gz
-cd jpeg-9
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --host=arm-none-linux-gnueabi
 make -j16
 make install
@@ -32,4 +28,3 @@ popd
 cp $BUILDDIR/lib/*.a .
 cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR
-

--- a/src/lib_aarch64/build_aarch64_libpng
+++ b/src/lib_aarch64/build_aarch64_libpng
@@ -1,17 +1,14 @@
 #!/bin/bash
-SRC_TARBALL=../../libpng-1.6.3.tgz
+LIB=libpng-1.6.3.tgz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 DESTPATH=`pwd`
 
 HOSTARCH=$(uname -m | \
-	sed -e s/i.86/x86/ \
-	    -e s/sun4u/sparc64/ \
-	    -e s/arm.*/arm/ \
-	    -e s/sa110/arm/ \
-	    -e s/ppc64/powerpc/ \
-	    -e s/ppc/powerpc/ \
-	    -e s/macppc/powerpc/\
-	    -e s/sh.*/sh/)
+	sed -e s/arm64/aarch64/ \
+	    -e s/armv8.*/aarch64/ \
+	    -e s/armv9.*/aarch64/)
 
 # if we are building on the host for the host and not cross-compiling
 if [ "aarch64" = $HOSTARCH ] ; then
@@ -22,8 +19,7 @@ fi
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf libpng-1.6.3.tgz
-cd libpng-1.6.3
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --host=arm-none-linux-gnueabi --with-zlib-prefix=$DESTPATH
 make -j16
 make install
@@ -32,4 +28,3 @@ cp $BUILDDIR/lib/*.a .
 cp $BUILDDIR/include/*.h .
 echo $CFLAGS
 rm -r -f $BUILDDIR
-

--- a/src/lib_aarch64/build_aarch64_zlib
+++ b/src/lib_aarch64/build_aarch64_zlib
@@ -1,16 +1,13 @@
 #!/bin/bash
-SRC_TARBALL=../../zlib-1.2.8.tar.gz
+LIB=zlib-1.2.8.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 HOSTARCH=$(uname -m | \
-	sed -e s/i.86/x86/ \
-	    -e s/sun4u/sparc64/ \
-	    -e s/arm.*/arm/ \
-	    -e s/sa110/arm/ \
-	    -e s/ppc64/powerpc/ \
-	    -e s/ppc/powerpc/ \
-	    -e s/macppc/powerpc/\
-	    -e s/sh.*/sh/)
+	sed -e s/arm64/aarch64/ \
+	    -e s/armv8.*/aarch64/ \
+	    -e s/armv9.*/aarch64/)
 
 # if we are building on the host for the host and not cross-compiling
 if [ "aarch64" = $HOSTARCH ] ; then
@@ -23,8 +20,7 @@ export CFLAGS=""
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf zlib-1.2.8.tar.gz
-cd zlib-1.2.8
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR
 make -j16
 make install
@@ -32,4 +28,3 @@ popd
 cp $BUILDDIR/lib/*.a .
 cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR
-

--- a/src/lib_armv6/build_armv6_fftw3
+++ b/src/lib_armv6/build_armv6_fftw3
@@ -1,5 +1,7 @@
 #!/bin/bash
-SRC_TARBALL=../../fftw-3.3.10.tar.gz
+LIB=fftw-3.3.10.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 HOSTARCH=$(uname -m | \
@@ -13,7 +15,7 @@ HOSTARCH=$(uname -m | \
 	    -e s/sh.*/sh/)
 
 # if we are building on the host for the host and not cross-compiling
-if [ "armv6" = $HOSTARCH ] ; then
+if [ "arm" = $HOSTARCH ] ; then
 export CC=gcc
 else
 export CC=/opt/rpi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/bin/arm-bcm2708hardfp-linux-gnueabi-gcc
@@ -23,12 +25,11 @@ export CFLAGS="-march=armv6zk -mfpu=vfp -mfloat-abi=hard -mcpu=arm1176jzf-s"
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --host=arm-none-linux-gnueabi
 make -j16
 make install
 popd
-cp $BUILDDIR/lib/libfftw*.a .
-cp $BUILDDIR/include/fftw3.h .
+cp $BUILDDIR/lib/*.a .
+cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR

--- a/src/lib_armv7hf/build_armv7hf_fftw3
+++ b/src/lib_armv7hf/build_armv7hf_fftw3
@@ -1,5 +1,7 @@
 #!/bin/bash
-SRC_TARBALL=../../fftw-3.3.10.tar.gz
+LIB=fftw-3.3.10.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 HOSTARCH=$(uname -m | \
@@ -13,22 +15,22 @@ HOSTARCH=$(uname -m | \
 	    -e s/sh.*/sh/)
 
 # if we are building on the host for the host and not cross-compiling
-if [ "armv7hf" = $HOSTARCH ] ; then
+if [ "arm" = $HOSTARCH ] ; then
 export CC=gcc
 else
 export CC=/opt/gcc-linaro-7.5.0-2019.12-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc
 fi
 
-export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8"
+#export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a8"
+export CFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard"
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --host=arm-none-linux-gnueabi
 make -j16
 make install
 popd
-cp $BUILDDIR/lib/libfftw3*.a .
-cp $BUILDDIR/include/fftw3.h .
+cp $BUILDDIR/lib/*.a .
+cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR

--- a/src/lib_x86_32/build_x86-32_fftw3
+++ b/src/lib_x86_32/build_x86-32_fftw3
@@ -1,16 +1,16 @@
 #!/bin/bash
-SRC_TARBALL=../../fftw-3.3.10.tar.gz
+LIB=fftw-3.3.10.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR --build=i686-pc-linux-gnu CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32
 make -j16
 make install
 popd
-cp $BUILDDIR/lib/libfftw*.a .
-cp $BUILDDIR/include/fftw3.h .
-#rm -r -f $BUILDDIR
-
+cp $BUILDDIR/lib/*.a .
+cp $BUILDDIR/include/*.h .
+rm -r -f $BUILDDIR

--- a/src/lib_x86_64/build_x86-64_fftw3
+++ b/src/lib_x86_64/build_x86-64_fftw3
@@ -1,16 +1,16 @@
 #!/bin/bash
-SRC_TARBALL=../../fftw-3.3.10.tar.gz
+LIB=fftw-3.3.10.tar.gz
+
+SRC_TARBALL=../../$LIB
 BUILDDIR=`mktemp -d`
 
 cp $SRC_TARBALL $BUILDDIR
 pushd $BUILDDIR
-tar -xf fftw-3.3.10.tar.gz
-cd fftw-3.3.10
+tar -xf $LIB --strip-components=1
 ./configure --prefix=$BUILDDIR #--enable-float
 make -j16
 make install
 popd
-cp $BUILDDIR/lib/libfftw*.a .
-cp $BUILDDIR/include/fftw3.h .
+cp $BUILDDIR/lib/*.a .
+cp $BUILDDIR/include/*.h .
 rm -r -f $BUILDDIR
-


### PR DESCRIPTION
Get the Makefile "(default)" build working again by searching the src/lib_<hostarch> for the fftw3 components.

Try to do a better job at normalizing the HOSTARCH. This is especially necessary now that the src/lib_<hostarch> directory will always be required for at least the fftw3 component, if not other libs, for a particular PLATFORM or HOSTARCH build. Updated README to provide additional tips for building.

Various build scripts updated to improve host vs native vs cross-compile environment detection as well as simplifying library version updates if necessary. Now just a one line change at the top of the build file.

The Makefile adds a DEBUG variable which will turn all the compiler warnings back on if needed. For example: make DEBUG=yes ...

Because the c source code seems to be machine-translated from the original modula-2 source into c, we're sort of dealt the hand we are given with the resulting c source. A fix to a warning in the c code could be overwritten  if not fixed at the upstream source. For the average user, warnings that can't really be fixed just clutter up the screen and may mask other notices during the link-process.